### PR TITLE
Fix: Safe clock function to return float when os.clock not found

### DIFF
--- a/moesif/core/helpers.lua
+++ b/moesif/core/helpers.lua
@@ -30,16 +30,16 @@ end
 
 local function safe_clock ()
     if os.clock == nil then
-        return 0.0
+        return string.format('%.2f', 0.0 * 1000)
     else
-        return os.clock()
+        return tostring(os.clock() * 1000)
     end
 end
 
 -- Function to get current time in milliseconds
 function _M.get_current_time_in_ms()
     local current_time_since_epoch = os.time(os.date("!*t"))
-    return os.date("!%Y-%m-%dT%H:%M:%S.", current_time_since_epoch) .. string.match(tostring(safe_clock() * 1000), "%d%.(%d+)")
+    return os.date("!%Y-%m-%dT%H:%M:%S.", current_time_since_epoch) .. string.match(safe_clock(), "%d%.(%d+)")
 end
 
 -- Function fetch raw body

--- a/moesif/plugins/log.lua
+++ b/moesif/plugins/log.lua
@@ -309,7 +309,7 @@ function _M.log_response(handler)
                         [":authority"] = "moesifprod",
                         ["content-type"] = "application/json",
                         ["x-moesif-application-id"] = ctx["application_id"],
-                        ["user-agent"] = "envoy-plugin-moesif/0.1.2"
+                        ["user-agent"] = "envoy-plugin-moesif/0.1.4"
                     }
                     local ok, compressed_body = pcall(core.lib_deflate["CompressDeflate"], core.lib_deflate, encode_value)
                     if not ok then 


### PR DESCRIPTION
Fix: Safe clock function to return float when os.clock not found
Refactor: Bump user-agent to 0.1.4